### PR TITLE
Highlight alternative operator names as keywords

### DIFF
--- a/after/syntax/cpp.vim
+++ b/after/syntax/cpp.vim
@@ -16,6 +16,9 @@ endif
 
 
 " Standard library {{{1
+syntax keyword cppSTLalternativeoperators
+        \ and or xor bitand bitor not and_eq or_eq xor_eq bitand_eq bitor_eq not_eq compl
+
 syntax keyword cppSTLdefine
         \ MB_CUR_MAX MB_LEN_MAX WCHAR_MAX WCHAR_MIN WEOF __STDC_UTF_16__ __STDC_UTF_32__
 


### PR DESCRIPTION
This would just add a few keywords as operators so that they stand out when using constructs such as `and not CONDITION` in an `if` statement.

As per https://en.cppreference.com/w/cpp/language/operator_alternative.