### PR TITLE
prevent highlighting if union/struct/enum is used in a type name

### DIFF
--- a/after/syntax/c.vim
+++ b/after/syntax/c.vim
@@ -39,11 +39,11 @@ endif
 
 " Highlight names in struct, union and enum declarations
 if get(g:, 'cpp_type_name_highlight', 1)
-    syn match cTypeName "\%(\%(\<struct\|union\|enum\)\s\+\)\@8<=\h\w*"
+    syn match cTypeName "\%(\<\%(struct\|union\|enum\)\s\+\)\@8<=\h\w*"
     hi def link cTypeName Type
 
     if &filetype ==# 'cpp'
-        syn match cTypeName "\%(\%(\<class\|using\|concept\|requires\)\s\+\)\@10<=\h\w*"
+        syn match cTypeName "\%(\<\%(class\|using\|concept\|requires\)\s\+\)\@10<=\h\w*"
     endif
 endif
 


### PR DESCRIPTION
```c
typedef struct {
// stuff here
} my_struct;

typedef struct {
 my_struct other; // other would not be highlighted 
} thing;

typedef union {
// stuff here
} my_union;

typedef struct {
 my_union other; // other would be highlighted before this pull request
} thing;
```

The change removes the highlighting on union/enum in names not just for struct